### PR TITLE
backgroundView should block taps

### DIFF
--- a/Pod/Classes/RappleActivityIndicatorView.swift
+++ b/Pod/Classes/RappleActivityIndicatorView.swift
@@ -357,7 +357,7 @@ open class RappleActivityIndicatorView: NSObject {
             keyWindow.addSubview(backgroundView!)
             
             let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapBlocker))
-            backgroundView.addGestureRecognizer(tapGestureRecognizer)
+            backgroundView?.addGestureRecognizer(tapGestureRecognizer)
             
             let dic = ["BG": backgroundView!]
             keyWindow.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[BG]|", options: .alignAllCenterY, metrics: nil, views: dic))
@@ -365,7 +365,7 @@ open class RappleActivityIndicatorView: NSObject {
         }
     }
     
-    fileprivate func tapBlocker() {
+    @objc fileprivate func tapBlocker() {
         //do nothing
     }
     

--- a/Pod/Classes/RappleActivityIndicatorView.swift
+++ b/Pod/Classes/RappleActivityIndicatorView.swift
@@ -353,13 +353,20 @@ open class RappleActivityIndicatorView: NSObject {
             backgroundView?.translatesAutoresizingMaskIntoConstraints = false
             backgroundView?.backgroundColor = getColor(key: RappleScreenBGColorKey).withAlphaComponent(0.4)
             backgroundView?.alpha = 1.0
-            backgroundView?.isUserInteractionEnabled = false
+            backgroundView?.isUserInteractionEnabled = true
             keyWindow.addSubview(backgroundView!)
+            
+            let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapBlocker))
+            backgroundView.addGestureRecognizer(tapGestureRecognizer)
             
             let dic = ["BG": backgroundView!]
             keyWindow.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[BG]|", options: .alignAllCenterY, metrics: nil, views: dic))
             keyWindow.addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "V:|[BG]|", options: .alignAllCenterX, metrics: nil, views: dic))
         }
+    }
+    
+    fileprivate func tapBlocker() {
+        //do nothing
     }
     
     /** create all UIs */

--- a/RappleProgressHUD.podspec
+++ b/RappleProgressHUD.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name             = "RappleProgressHUD"
-s.version          = "2.1.0"
+s.version          = "2.1.1"
 s.summary          = "Flexible Activity & Progress indicator for Swift."
 
 s.description      = <<-DESC


### PR DESCRIPTION
As a general convention, when a progress HUD is displayed to a user, it is usually to tell the user "hang on while we do this action" - as such you typically are trying to block your UI with something so that you can make sure the task completes before you allow the user to do something else.   The background view currently allows taps to pass through to the underlying UI allowing the user to continue to interact with the interface while the progress HUD is displayed.   This PR adds a tap gesture recognizer to the the backgroundView to at least capture all taps and prevent them from being received by the underlying UI.  (other gestures will continue to pass through)