### PR TITLE
bug/keyWindow.isUserInteractionEnabled-race-condition

### DIFF
--- a/Pod/Classes/RappleAIAction.swift
+++ b/Pod/Classes/RappleAIAction.swift
@@ -57,6 +57,8 @@ extension RappleActivityIndicatorView {
             progress.backgroundView?.alpha = 1.0
             
         }, completion: { (finished) -> Void in
+            sharedInstance.keyWindow.isUserInteractionEnabled = false
+            
             progress.createActivityIndicator()
         })
     }


### PR DESCRIPTION
Set keyWindow userInteraction to false in animation completion block, because of race condition that can occur in stopPrivateAnimating() when the cleanup animation completion block sets it to false.

This race condition occurs if a ProgressHUD is started immediately after another has been stopped. In which case sharedInstance.keyWindow.userInteraction is set to true in the stopPrivateAnimating animation completion block after the new animation has already started. 